### PR TITLE
Made dump_per_read_statistics an executable script

### DIFF
--- a/scripts/dump_per_read_statistics.py
+++ b/scripts/dump_per_read_statistics.py
@@ -1,13 +1,16 @@
 #! /usr/bin/env python
+"""Dump per-read statistics
+
+This script takes a per-read statistics file and dumps its contents out into a tab-separated values file. The columns in the file are 'chrm', 'pos', 'strand', 'read_id' and 'stat'.
+"""
 from tombo import tombo_stats
 from tombo.tombo_helper import intervalData
+import argparse
 import sys
 import os
 
-def main():
-    if len(sys.argv) < 2:
-        sys.exit('missing argument for filename')
-    fname = sys.argv[1]
+def extract_per_read_stats(fname):
+    """Dump per-read statistics to tab-separated values"""
     if not os.path.isfile(fname):
         sys.exit('"{}" is not a valid file'.format(fname))
 
@@ -24,5 +27,17 @@ def main():
                     out_fp.write('{}\t{}\t{}\t{}\t{}\n'.format(
                         chrm, pos, strand, read_id, stat))
 
+
+def main(fname):
+    extract_per_read_stats(fname)
+
+
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'input_file',
+        type=str,
+        help="the per-read statistics file produced by tombo"
+    )
+    args = parser.parse_args()
+    main(args.input_file)

--- a/scripts/dump_per_read_statistics.py
+++ b/scripts/dump_per_read_statistics.py
@@ -1,15 +1,28 @@
+#! /usr/bin/env python
 from tombo import tombo_stats
 from tombo.tombo_helper import intervalData
+import sys
+import os
 
-pr_stats = tombo_stats.PerReadStats('path/to/stats.per_read_stats')
+def main():
+    if len(sys.argv) < 2:
+        sys.exit('missing argument for filename')
+    fname = sys.argv[1]
+    if not os.path.isfile(fname):
+        sys.exit('"{}" is not a valid file'.format(fname))
 
-with open('per_read_stats.txt', 'w') as out_fp:
-    out_fp.write('{}\t{}\t{}\t{}\t{}\n'.format(
-        'chrm', 'pos', 'strand', 'read_id', 'stat'))
-    for (chrm, strand), cs_blocks in pr_stats.blocks_index.items():
-        for start, block_name in cs_blocks.items():
-            for pos, stat, read_id in pr_stats.get_region_per_read_stats(
-                    intervalData(chrm, start, start + pr_stats.region_size,
-                                 strand)):
-                out_fp.write('{}\t{}\t{}\t{}\t{}\n'.format(
-                    chrm, pos, strand, read_id, stat))
+    pr_stats = tombo_stats.PerReadStats(fname)
+
+    with open('per_read_stats.txt', 'w') as out_fp:
+        out_fp.write('{}\t{}\t{}\t{}\t{}\n'.format(
+            'chrm', 'pos', 'strand', 'read_id', 'stat'))
+        for (chrm, strand), cs_blocks in pr_stats.blocks_index.items():
+            for start, block_name in cs_blocks.items():
+                for pos, stat, read_id in pr_stats.get_region_per_read_stats(
+                        intervalData(chrm, start, start + pr_stats.region_size,
+                                    strand)):
+                    out_fp.write('{}\t{}\t{}\t{}\t{}\n'.format(
+                        chrm, pos, strand, read_id, stat))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/dump_per_read_statistics.py
+++ b/scripts/dump_per_read_statistics.py
@@ -9,14 +9,14 @@ import argparse
 import sys
 import os
 
-def extract_per_read_stats(fname):
+def extract_per_read_stats(input_file, output_file):
     """Dump per-read statistics to tab-separated values"""
-    if not os.path.isfile(fname):
-        sys.exit('"{}" is not a valid file'.format(fname))
+    if not os.path.isfile(input_file):
+        sys.exit('"{}" is not a valid file'.format(input_file))
 
-    pr_stats = tombo_stats.PerReadStats(fname)
+    pr_stats = tombo_stats.PerReadStats(input_file)
 
-    with open('per_read_stats.txt', 'w') as out_fp:
+    with open(output_file, 'w') as out_fp:
         out_fp.write('{}\t{}\t{}\t{}\t{}\n'.format(
             'chrm', 'pos', 'strand', 'read_id', 'stat'))
         for (chrm, strand), cs_blocks in pr_stats.blocks_index.items():
@@ -28,8 +28,8 @@ def extract_per_read_stats(fname):
                         chrm, pos, strand, read_id, stat))
 
 
-def main(fname):
-    extract_per_read_stats(fname)
+def main(input_file, output_file):
+    extract_per_read_stats(input_file, output_file)
 
 
 if __name__ == '__main__':
@@ -39,5 +39,12 @@ if __name__ == '__main__':
         type=str,
         help="the per-read statistics file produced by tombo"
     )
+    parser.add_argument(
+        '-o',
+        '--output_file',
+        default='per_read_stats.txt',
+        type=str,
+        help="the name of the output tsv file (default: 'per_read_stats.txt')"
+    )
     args = parser.parse_args()
-    main(args.input_file)
+    main(args.input_file, args.output_file)


### PR DESCRIPTION
Turns `dump_per_read_statistics.py` into an executable script (assuming permissions are set accordingly). Runs by `dump_per_read_statistics.py [-h] [-o OUTPUT_FILE] input_file`.